### PR TITLE
Remove unimplemented Android functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ const NativeModule =
   NativeModules.VydiaRNFileUploader || NativeModules.RNFileUploader; // iOS is VydiaRNFileUploader and Android is RNFileUploader
 const eventPrefix = 'RNFileUploader-';
 
-const eventEmitter = new NativeEventEmitter(NativeModule);
+const iosEventEmitter = Platform.OS == "ios" ? new NativeEventEmitter(NativeModule) : undefined;
 
 /*
 Gets file information for the path specified.
@@ -104,7 +104,7 @@ Events (id is always the upload ID):
 */
 export const addListener = (eventType: UploadEvent, uploadId: string, listener: Function) => {
   if (Platform.OS === 'ios') {
-    return eventEmitter.addListener(eventPrefix + eventType, (data) => {
+    return iosEventEmitter.addListener(eventPrefix + eventType, (data) => {
       if (!uploadId || !data || !data.id || data.id === uploadId) {
         listener(data)
       }
@@ -117,40 +117,4 @@ export const addListener = (eventType: UploadEvent, uploadId: string, listener: 
   })
 }
 
-// call this to let the OS it can suspend again
-// it will be called after a short timeout if it isn't called at all
-export const canSuspendIfBackground = () => {
-  if (Platform.OS === 'ios') {
-    NativeModule.canSuspendIfBackground();
-  }
-};
-
-// returns remaining background time in seconds
-export const getRemainingBgTime = (): Promise<number> => {
-  if (Platform.OS === 'ios') {
-    return NativeModule.getRemainingBgTime();
-  }
-  return Promise.resolve(10 * 60 * 24) // dummy for android, large number
-};
-
-// marks the beginning of a background task and returns its ID
-// in order to request extra background time
-// do not call more than once without calling endBackgroundTask
-// useful if we need to do more background processing in addition to network requests
-// canSuspendIfBackground should still be called in case we run out of time.
-export const beginBackgroundTask = (): Promise<number> => {
-  if (Platform.OS === 'ios') {
-    return NativeModule.beginBackgroundTask();
-  }
-  return Promise.resolve(0); // dummy for android
-};
-
-// marks the end of background task using the id returned by begin
-// failing to call this might end up on app termination
-export const endBackgroundTask = (id: number) => {
-  if (Platform.OS === 'ios') {
-    NativeModule.endBackgroundTask(id);
-  }
-};
-
-export default { startUpload, cancelUpload, addListener, getFileInfo, canSuspendIfBackground, getRemainingBgTime, beginBackgroundTask, endBackgroundTask }
+export default { startUpload, cancelUpload, addListener, getFileInfo }


### PR DESCRIPTION
The `NativeEventEmitter` was unused on Android, and it was causing this warning: `new NativeEventEmitter() was called with a non-null argument without the required removeListeners method`.

Also removed a bunch of methods that didn't have Android implementations.
